### PR TITLE
Add .NET 10 support with Swashbuckle.AspNetCore v10 and Microsoft.Ope…

### DIFF
--- a/src/MicroElements.OpenApi.FluentValidation/MicroElements.OpenApi.FluentValidation.csproj
+++ b/src/MicroElements.OpenApi.FluentValidation/MicroElements.OpenApi.FluentValidation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/MicroElements.Swashbuckle.FluentValidation.AspNetCore/MicroElements.Swashbuckle.FluentValidation.AspNetCore.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation.AspNetCore/MicroElements.Swashbuckle.FluentValidation.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/src/MicroElements.Swashbuckle.FluentValidation/AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/AspNetCore/ServiceCollectionExtensions.cs
@@ -9,7 +9,9 @@ using MicroElements.Swashbuckle.FluentValidation.Generation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+#if !OPENAPI_V2
 using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MicroElements.Swashbuckle.FluentValidation.AspNetCore

--- a/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRule.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/FluentValidationRule.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Validators;
 using MicroElements.OpenApi.FluentValidation;
+#if !OPENAPI_V2
 using Microsoft.OpenApi.Models;
+#endif
 
 namespace MicroElements.Swashbuckle.FluentValidation
 {

--- a/src/MicroElements.Swashbuckle.FluentValidation/GlobalUsings.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/GlobalUsings.cs
@@ -1,0 +1,10 @@
+// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// OpenApi 2.x uses Microsoft.OpenApi namespace for models (no .Models sub-namespace)
+// OpenApi 1.x uses Microsoft.OpenApi.Models namespace
+#if OPENAPI_V2
+global using Microsoft.OpenApi;
+#else
+global using Microsoft.OpenApi.Models;
+#endif

--- a/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
+++ b/src/MicroElements.Swashbuckle.FluentValidation/MicroElements.Swashbuckle.FluentValidation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -11,9 +11,17 @@
     <PackageTags>swagger swashbuckle FluentValidation aspnetcore</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <DefineConstants>$(DefineConstants);OPENAPI_V2</DefineConstants>
+  </PropertyGroup>
+
   <Import Project="..\common.props" />
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
   </ItemGroup>
 

--- a/src/MicroElements.Swashbuckle.FluentValidation/OpenApi/OpenApiExtensions.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/OpenApi/OpenApiExtensions.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+#if !OPENAPI_V2
 using Microsoft.OpenApi.Models;
+#endif
 
 namespace MicroElements.OpenApi
 {
@@ -20,7 +22,7 @@ namespace MicroElements.OpenApi
         {
             if (schemaProperty.MinLength.HasValue && schemaProperty.MinLength > 0)
             {
-                schemaProperty.Nullable = false;
+                OpenApiSchemaCompatibility.SetNotNullable(schemaProperty);
             }
         }
 

--- a/src/MicroElements.Swashbuckle.FluentValidation/OpenApi/OpenApiSchemaCompatibility.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/OpenApi/OpenApiSchemaCompatibility.cs
@@ -1,0 +1,481 @@
+// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
+
+namespace MicroElements.OpenApi
+{
+    /// <summary>
+    /// Compatibility layer for Microsoft.OpenApi 1.x and 2.x differences.
+    /// </summary>
+    internal static class OpenApiSchemaCompatibility
+    {
+        /// <summary>
+        /// Checks if schema type is string.
+        /// </summary>
+        public static bool IsStringType(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            return schema.Type.HasValue && schema.Type.Value.HasFlag(JsonSchemaType.String);
+#else
+            return schema.Type == "string";
+#endif
+        }
+
+        /// <summary>
+        /// Checks if schema type is array.
+        /// </summary>
+        public static bool IsArrayType(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            return schema.Type.HasValue && schema.Type.Value.HasFlag(JsonSchemaType.Array);
+#else
+            return schema.Type == "array";
+#endif
+        }
+
+        /// <summary>
+        /// Sets schema as not nullable.
+        /// </summary>
+        public static void SetNotNullable(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            if (schema.Type.HasValue)
+            {
+                schema.Type &= ~JsonSchemaType.Null;
+            }
+#else
+            schema.Nullable = false;
+#endif
+        }
+
+        /// <summary>
+        /// Gets nullable value from schema.
+        /// </summary>
+        public static bool GetNullable(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            return schema.Type.HasValue && schema.Type.Value.HasFlag(JsonSchemaType.Null);
+#else
+            return schema.Nullable;
+#endif
+        }
+
+#if OPENAPI_V2
+        /// <summary>
+        /// Gets nullable value from IOpenApiSchema interface.
+        /// </summary>
+        public static bool GetNullable(IOpenApiSchema schema)
+        {
+            if (schema is OpenApiSchema openApiSchema)
+                return GetNullable(openApiSchema);
+            return false;
+        }
+#endif
+
+        /// <summary>
+        /// Sets nullable value on schema.
+        /// </summary>
+        public static void SetNullable(OpenApiSchema schema, bool value)
+        {
+#if OPENAPI_V2
+            if (value)
+            {
+                if (schema.Type.HasValue)
+                    schema.Type |= JsonSchemaType.Null;
+            }
+            else
+            {
+                SetNotNullable(schema);
+            }
+#else
+            schema.Nullable = value;
+#endif
+        }
+
+        /// <summary>
+        /// Ensures Required collection is initialized.
+        /// </summary>
+        public static void EnsureRequiredInitialized(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            schema.Required ??= new HashSet<string>();
+#endif
+            // In v1, Required is always initialized
+        }
+
+        /// <summary>
+        /// Adds property to Required collection safely.
+        /// </summary>
+        public static void AddRequired(OpenApiSchema schema, string propertyName)
+        {
+            EnsureRequiredInitialized(schema);
+            if (!schema.Required.Contains(propertyName))
+            {
+                schema.Required.Add(propertyName);
+            }
+        }
+
+        /// <summary>
+        /// Checks if Required collection contains property.
+        /// </summary>
+        public static bool RequiredContains(OpenApiSchema schema, string propertyName)
+        {
+#if OPENAPI_V2
+            return schema.Required?.Contains(propertyName) ?? false;
+#else
+            return schema.Required.Contains(propertyName);
+#endif
+        }
+
+        /// <summary>
+        /// Ensures AllOf collection is initialized.
+        /// </summary>
+        public static void EnsureAllOfInitialized(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            schema.AllOf ??= new List<IOpenApiSchema>();
+#endif
+        }
+
+        /// <summary>
+        /// Gets count of AllOf items matching predicate.
+        /// </summary>
+        public static int AllOfCountWhere(OpenApiSchema schema, Func<OpenApiSchema, bool> predicate)
+        {
+#if OPENAPI_V2
+            return schema.AllOf?.OfType<OpenApiSchema>().Count(predicate) ?? 0;
+#else
+            return schema.AllOf.Count(predicate);
+#endif
+        }
+
+        /// <summary>
+        /// Adds schema to AllOf collection safely.
+        /// </summary>
+        public static void AddAllOf(OpenApiSchema schema, OpenApiSchema child)
+        {
+            EnsureAllOfInitialized(schema);
+            schema.AllOf.Add(child);
+        }
+
+        /// <summary>
+        /// Checks if Properties dictionary contains key.
+        /// </summary>
+        public static bool PropertiesContainsKey(OpenApiSchema schema, string key)
+        {
+            return schema.Properties?.ContainsKey(key) ?? false;
+        }
+
+        /// <summary>
+        /// Gets Properties count safely.
+        /// </summary>
+        public static int PropertiesCount(OpenApiSchema schema)
+        {
+            return schema.Properties?.Count ?? 0;
+        }
+
+        /// <summary>
+        /// Gets property from schema by key.
+        /// </summary>
+        public static OpenApiSchema? GetProperty(OpenApiSchema schema, string key)
+        {
+#if OPENAPI_V2
+            if (schema.Properties?.TryGetValue(key, out var property) == true)
+                return property as OpenApiSchema;
+            return null;
+#else
+            if (schema.Properties?.TryGetValue(key, out var property) == true)
+                return property;
+            return null;
+#endif
+        }
+
+        /// <summary>
+        /// Tries to get property from schema by key.
+        /// </summary>
+        public static bool TryGetProperty(OpenApiSchema schema, string key, out OpenApiSchema? property)
+        {
+#if OPENAPI_V2
+            if (schema.Properties?.TryGetValue(key, out var prop) == true)
+            {
+                property = prop as OpenApiSchema;
+                return property != null;
+            }
+            property = null;
+            return false;
+#else
+            if (schema.Properties?.TryGetValue(key, out var prop) == true)
+            {
+                property = prop;
+                return true;
+            }
+            property = null;
+            return false;
+#endif
+        }
+
+        /// <summary>
+        /// Sets ExclusiveMinimum on schema.
+        /// </summary>
+        public static void SetExclusiveMinimum(OpenApiSchema schema, bool value)
+        {
+#if OPENAPI_V2
+            // In OpenAPI 3.1 / OpenApi 2.x, exclusiveMinimum is a number (string), not a boolean
+            // When exclusive, the minimum value is stored in exclusiveMinimum instead
+            if (value && !string.IsNullOrEmpty(schema.Minimum))
+            {
+                schema.ExclusiveMinimum = schema.Minimum;
+                schema.Minimum = null;
+            }
+#else
+            schema.ExclusiveMinimum = value;
+#endif
+        }
+
+        /// <summary>
+        /// Sets ExclusiveMaximum on schema.
+        /// </summary>
+        public static void SetExclusiveMaximum(OpenApiSchema schema, bool value)
+        {
+#if OPENAPI_V2
+            // In OpenAPI 3.1 / OpenApi 2.x, exclusiveMaximum is a number (string), not a boolean
+            if (value && !string.IsNullOrEmpty(schema.Maximum))
+            {
+                schema.ExclusiveMaximum = schema.Maximum;
+                schema.Maximum = null;
+            }
+#else
+            schema.ExclusiveMaximum = value;
+#endif
+        }
+
+        /// <summary>
+        /// Sets Minimum on schema.
+        /// </summary>
+        public static void SetMinimum(OpenApiSchema schema, decimal value)
+        {
+#if OPENAPI_V2
+            schema.Minimum = value.ToString(CultureInfo.InvariantCulture);
+#else
+            schema.Minimum = value;
+#endif
+        }
+
+        /// <summary>
+        /// Sets Maximum on schema.
+        /// </summary>
+        public static void SetMaximum(OpenApiSchema schema, decimal value)
+        {
+#if OPENAPI_V2
+            schema.Maximum = value.ToString(CultureInfo.InvariantCulture);
+#else
+            schema.Maximum = value;
+#endif
+        }
+
+        /// <summary>
+        /// Gets Minimum from schema.
+        /// </summary>
+        public static decimal? GetMinimum(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            if (decimal.TryParse(schema.Minimum, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+                return result;
+            return null;
+#else
+            return schema.Minimum;
+#endif
+        }
+
+        /// <summary>
+        /// Gets Maximum from schema.
+        /// </summary>
+        public static decimal? GetMaximum(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            if (decimal.TryParse(schema.Maximum, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+                return result;
+            return null;
+#else
+            return schema.Maximum;
+#endif
+        }
+
+        /// <summary>
+        /// Sets Minimum with comparison logic (takes the larger of existing and new value).
+        /// </summary>
+        public static void SetNewMinimum(OpenApiSchema schema, decimal newValue)
+        {
+            var current = GetMinimum(schema);
+            var finalValue = current.HasValue ? Math.Max(current.Value, newValue) : newValue;
+            SetMinimum(schema, finalValue);
+        }
+
+        /// <summary>
+        /// Sets Maximum with comparison logic (takes the smaller of existing and new value).
+        /// </summary>
+        public static void SetNewMaximum(OpenApiSchema schema, decimal newValue)
+        {
+            var current = GetMaximum(schema);
+            var finalValue = current.HasValue ? Math.Min(current.Value, newValue) : newValue;
+            SetMaximum(schema, finalValue);
+        }
+
+        /// <summary>
+        /// Copies ExclusiveMinimum from source to target schema.
+        /// </summary>
+        public static void CopyExclusiveMinimum(OpenApiSchema target, OpenApiSchema source)
+        {
+            target.ExclusiveMinimum = source.ExclusiveMinimum;
+        }
+
+        /// <summary>
+        /// Copies ExclusiveMaximum from source to target schema.
+        /// </summary>
+        public static void CopyExclusiveMaximum(OpenApiSchema target, OpenApiSchema source)
+        {
+            target.ExclusiveMaximum = source.ExclusiveMaximum;
+        }
+
+        /// <summary>
+        /// Copies Minimum from source to target schema.
+        /// </summary>
+        public static void CopyMinimum(OpenApiSchema target, OpenApiSchema source)
+        {
+            target.Minimum = source.Minimum;
+        }
+
+        /// <summary>
+        /// Copies Maximum from source to target schema.
+        /// </summary>
+        public static void CopyMaximum(OpenApiSchema target, OpenApiSchema source)
+        {
+            target.Maximum = source.Maximum;
+        }
+
+#if OPENAPI_V2
+        /// <summary>
+        /// Copies Minimum from IOpenApiSchema source to target schema.
+        /// </summary>
+        public static void CopyMinimum(OpenApiSchema target, IOpenApiSchema source)
+        {
+            target.Minimum = source.Minimum;
+        }
+
+        /// <summary>
+        /// Copies Maximum from IOpenApiSchema source to target schema.
+        /// </summary>
+        public static void CopyMaximum(OpenApiSchema target, IOpenApiSchema source)
+        {
+            target.Maximum = source.Maximum;
+        }
+
+        /// <summary>
+        /// Copies ExclusiveMinimum from IOpenApiSchema source to target schema.
+        /// </summary>
+        public static void CopyExclusiveMinimum(OpenApiSchema target, IOpenApiSchema source)
+        {
+            target.ExclusiveMinimum = source.ExclusiveMinimum;
+        }
+
+        /// <summary>
+        /// Copies ExclusiveMaximum from IOpenApiSchema source to target schema.
+        /// </summary>
+        public static void CopyExclusiveMaximum(OpenApiSchema target, IOpenApiSchema source)
+        {
+            target.ExclusiveMaximum = source.ExclusiveMaximum;
+        }
+#endif
+
+        /// <summary>
+        /// Gets Items property from schema.
+        /// </summary>
+        public static OpenApiSchema? GetItems(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            return schema.Items as OpenApiSchema;
+#else
+            return schema.Items;
+#endif
+        }
+
+        /// <summary>
+        /// Gets AllOf collection as OpenApiSchema enumerable.
+        /// </summary>
+        public static IEnumerable<OpenApiSchema> GetAllOf(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            return schema.AllOf?.OfType<OpenApiSchema>() ?? Enumerable.Empty<OpenApiSchema>();
+#else
+            return schema.AllOf ?? Enumerable.Empty<OpenApiSchema>();
+#endif
+        }
+
+        /// <summary>
+        /// Gets OneOf collection as OpenApiSchema enumerable.
+        /// </summary>
+        public static IEnumerable<OpenApiSchema> GetOneOf(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            return schema.OneOf?.OfType<OpenApiSchema>() ?? Enumerable.Empty<OpenApiSchema>();
+#else
+            return schema.OneOf ?? Enumerable.Empty<OpenApiSchema>();
+#endif
+        }
+
+        /// <summary>
+        /// Gets AnyOf collection as OpenApiSchema enumerable.
+        /// </summary>
+        public static IEnumerable<OpenApiSchema> GetAnyOf(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            return schema.AnyOf?.OfType<OpenApiSchema>() ?? Enumerable.Empty<OpenApiSchema>();
+#else
+            return schema.AnyOf ?? Enumerable.Empty<OpenApiSchema>();
+#endif
+        }
+
+        /// <summary>
+        /// Gets Properties dictionary values as OpenApiSchema enumerable.
+        /// </summary>
+        public static IEnumerable<KeyValuePair<string, OpenApiSchema>> GetProperties(OpenApiSchema schema)
+        {
+#if OPENAPI_V2
+            if (schema.Properties == null)
+                return Enumerable.Empty<KeyValuePair<string, OpenApiSchema>>();
+            return schema.Properties
+                .Select(kvp => new KeyValuePair<string, OpenApiSchema>(kvp.Key, (OpenApiSchema)kvp.Value));
+#else
+            return schema.Properties ?? Enumerable.Empty<KeyValuePair<string, OpenApiSchema>>();
+#endif
+        }
+
+#if OPENAPI_V2
+        /// <summary>
+        /// Copies all validation-related properties from source to target.
+        /// </summary>
+        public static void CopyValidationProperties(OpenApiSchema target, IOpenApiSchema source)
+        {
+            target.MinLength = source.MinLength;
+            target.MaxLength = source.MaxLength;
+            target.Pattern = source.Pattern;
+            target.Minimum = source.Minimum;
+            target.Maximum = source.Maximum;
+            target.ExclusiveMinimum = source.ExclusiveMinimum;
+            target.ExclusiveMaximum = source.ExclusiveMaximum;
+            // Can't copy Enum and AllOf directly due to interface limitations
+            // These need special handling if needed
+        }
+#endif
+    }
+
+}

--- a/src/MicroElements.Swashbuckle.FluentValidation/OpenApiRuleContext.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/OpenApiRuleContext.cs
@@ -4,8 +4,11 @@
 using System;
 using FluentValidation;
 using FluentValidation.Validators;
+using MicroElements.OpenApi;
 using MicroElements.OpenApi.FluentValidation;
+#if !OPENAPI_V2
 using Microsoft.OpenApi.Models;
+#endif
 
 namespace MicroElements.Swashbuckle.FluentValidation
 {
@@ -36,14 +39,15 @@ namespace MicroElements.Swashbuckle.FluentValidation
         {
             get
             {
-                if (!Schema.Properties.ContainsKey(PropertyKey))
+                if (!OpenApiSchemaCompatibility.PropertiesContainsKey(Schema, PropertyKey))
                 {
                     Type? schemaType = ValidationRuleInfo.GetReflectionContext()?.Type;
                     throw new ApplicationException($"Schema for type '{schemaType}' does not contain property '{PropertyKey}'.\nRegister {typeof(INameResolver)} if name in type differs from name in json.");
                 }
 
-                var schemaProperty = Schema.Properties[PropertyKey];
-                return !ValidationRuleInfo.IsCollectionRule() ? schemaProperty : schemaProperty.Items;
+                var schemaProperty = OpenApiSchemaCompatibility.GetProperty(Schema, PropertyKey)!;
+                var items = OpenApiSchemaCompatibility.GetItems(schemaProperty);
+                return !ValidationRuleInfo.IsCollectionRule() ? schemaProperty : items!;
             }
         }
 

--- a/src/MicroElements.Swashbuckle.FluentValidation/SchemaGenerationContext.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/SchemaGenerationContext.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using FluentValidation.Validators;
 using MicroElements.OpenApi.FluentValidation;
+#if !OPENAPI_V2
 using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MicroElements.Swashbuckle.FluentValidation

--- a/src/MicroElements.Swashbuckle.FluentValidation/Swashbuckle/FluentValidationRulesScopeAdapter.cs
+++ b/src/MicroElements.Swashbuckle.FluentValidation/Swashbuckle/FluentValidationRulesScopeAdapter.cs
@@ -5,7 +5,9 @@ using System;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+#if !OPENAPI_V2
 using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MicroElements.Swashbuckle.FluentValidation
@@ -41,10 +43,17 @@ namespace MicroElements.Swashbuckle.FluentValidation
         }
 
         /// <inheritdoc />
+#if OPENAPI_V2
+        public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
+        {
+            _fluentValidationRules.Apply(schema, context);
+        }
+#else
         public void Apply(OpenApiSchema schema, SchemaFilterContext context)
         {
             _fluentValidationRules.Apply(schema, context);
         }
+#endif
     }
 
     /// <summary>

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/IFormFileTests.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/IFormFileTests.cs
@@ -2,6 +2,11 @@
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
@@ -31,11 +36,11 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             var schemaRepository = new SchemaRepository();
             var referenceSchema = SchemaGenerator(new UploadFileRequestValidator()).GenerateSchema(typeof(UploadFileRequest), schemaRepository);
 
-            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            var fileProperty = schema.Properties[nameof(UploadFileRequest.File)];
-            fileProperty.Type.Should().Be("string");
+            var schema = schemaRepository.GetSchema(referenceSchema.GetRefId()!);
+            var fileProperty = schema.GetProperty(nameof(UploadFileRequest.File))!;
+            fileProperty.GetTypeString().Should().Be("string");
             fileProperty.Format.Should().Be("binary");
-            fileProperty.Nullable.Should().Be(false);
+            fileProperty.IsNullable().Should().Be(false);
         }
     }
 }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/Issue94.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/Issue94.cs
@@ -2,6 +2,11 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using FluentValidation;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
@@ -70,10 +75,10 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             var referenceSchema = SchemaGenerator(new Person.PersonValidator())
                 .GenerateSchema(typeof(Person), schemaRepository);
 
-            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            var schema = schemaRepository.GetSchema(referenceSchema.GetRefId()!);
             schema.Properties.Keys.Should().BeEquivalentTo("Name", "Emails");
-            var nameProperty = schema.Properties[nameof(Person.Name)];
-            nameProperty.Type.Should().Be("string");
+            var nameProperty = schema.GetProperty(nameof(Person.Name))!;
+            nameProperty.GetTypeString().Should().Be("string");
             nameProperty.MaxLength.Should().Be(101);
         }
     }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/MicroElements.Swashbuckle.FluentValidation.Tests.csproj
@@ -1,19 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <DefineConstants>$(DefineConstants);OPENAPI_V2</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.2.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.25" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/MultipleMatchRules.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/MultipleMatchRules.cs
@@ -1,5 +1,10 @@
 using FluentAssertions;
 using FluentValidation;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
@@ -58,8 +63,8 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             // *********************************
 
             var schema = new SchemaRepository().GenerateSchemaForValidator(new PhoneEntity.Validator());
-            var numberProp = schema.Properties[nameof(PhoneEntity.MobilePhoneNumber)];
-            numberProp.Type.Should().Be("string");
+            var numberProp = schema.GetProperty(nameof(PhoneEntity.MobilePhoneNumber))!;
+            numberProp.GetTypeString().Should().Be("string");
         }
     }
 }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/SetValidatorShouldNotSetParentPropertiesTest.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/SetValidatorShouldNotSetParentPropertiesTest.cs
@@ -1,6 +1,11 @@
 using System.Collections.Generic;
 using FluentAssertions;
 using FluentValidation;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
@@ -43,14 +48,14 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             var schemaRepository = new SchemaRepository();
             var referenceSchema = SchemaGenerator(new ModelValidator()).GenerateSchema(typeof(Model), schemaRepository);
 
-            var modelSchema = schemaRepository.Schemas["Model"];
+            var modelSchema = schemaRepository.GetSchema("Model");
             var listItemsProperty = modelSchema.Properties[nameof(Model.ListItems)];
             var subModelProperty = modelSchema.Properties[nameof(Model.SubModel)];
             listItemsProperty.Should().NotBeNull();
             subModelProperty.Should().NotBeNull();
             modelSchema.Required.Should().BeEmpty(because: "No required in Model");
 
-            var subModelSchema = schemaRepository.Schemas["SubModel"];
+            var subModelSchema = schemaRepository.GetSchema("SubModel");
             var subModelListItemsProperty = subModelSchema.Properties[nameof(SubModel.ListItems)];
             subModelListItemsProperty.Should().NotBeNull();
             subModelSchema.Required.Should().Contain(nameof(SubModel.ListItems), because: "ListItems is required in SubModel");

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/SetValidatorTest.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/SetValidatorTest.cs
@@ -1,5 +1,10 @@
 using FluentAssertions;
 using FluentValidation;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
@@ -50,9 +55,9 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             var schemaRepository = new SchemaRepository();
             var referenceSchema = SchemaGenerator(new RegisterUserRequestValidator()).GenerateSchema(typeof(RegisterUserRequest), schemaRepository);
 
-            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            var emailProperty = schema.Properties[nameof(RegisterUserRequest.Email)];
-            emailProperty.Type.Should().Be("string");
+            var schema = schemaRepository.GetSchema(referenceSchema.GetRefId()!);
+            var emailProperty = schema.GetProperty(nameof(RegisterUserRequest.Email))!;
+            emailProperty.GetTypeString().Should().Be("string");
             emailProperty.Format.Should().Be("email");
             emailProperty.MinLength.Should().Be(1);
         }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/SwaggerTestHost.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/SwaggerTestHost.cs
@@ -5,7 +5,11 @@ using Microsoft.AspNetCore.Mvc;
 using MicroElements.OpenApi.FluentValidation;
 using MicroElements.Swashbuckle.FluentValidation.AspNetCore;
 using Microsoft.Extensions.DependencyInjection;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
 using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -63,9 +67,9 @@ public class SwaggerTestHost
         var schemaGenerator = ServiceProvider.GetService<ISchemaGenerator>();
         if (schemaGenerator == null)
             throw new InvalidOperationException("ISchemaGenerator service not found. Make sure to call Configure() first.");
-        
+
         var openApiSchema = schemaGenerator.GenerateSchema(typeof(TModel), SchemaRepository);
-        schema = SchemaRepository.Schemas[openApiSchema.Reference.Id];
+        schema = SchemaRepository.GenerateAndResolve<TModel>(openApiSchema);
         return this;
     }
 }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/TestCompatibility.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/TestCompatibility.cs
@@ -1,0 +1,277 @@
+// Copyright (c) MicroElements. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MicroElements.Swashbuckle.FluentValidation.Tests;
+
+/// <summary>
+/// Compatibility helpers for OpenApi v1/v2 differences in tests.
+/// </summary>
+internal static class TestCompatibility
+{
+    /// <summary>
+    /// Gets schema from SchemaRepository by key.
+    /// </summary>
+    public static OpenApiSchema GetSchema(this SchemaRepository repository, string key)
+    {
+#if OPENAPI_V2
+        return repository.Schemas[key] as OpenApiSchema ?? throw new System.Exception($"Schema '{key}' not found or not OpenApiSchema");
+#else
+        return repository.Schemas[key];
+#endif
+    }
+
+#if OPENAPI_V2
+    /// <summary>
+    /// Gets schema from SchemaRepository by reference.
+    /// </summary>
+    public static OpenApiSchema GetSchemaByRef(this SchemaRepository repository, IOpenApiSchema schema)
+    {
+        if (schema is OpenApiSchemaReference schemaRef)
+        {
+            var refId = schemaRef.Reference?.Id;
+            if (refId != null && repository.Schemas.TryGetValue(refId, out var result))
+                return result as OpenApiSchema ?? new OpenApiSchema();
+        }
+        return schema as OpenApiSchema ?? new OpenApiSchema();
+    }
+#endif
+
+    /// <summary>
+    /// Gets schema from SchemaRepository by reference.
+    /// </summary>
+    public static OpenApiSchema GetSchemaByRef(this SchemaRepository repository, OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        // In OpenApi 2.x, we need to check if it's a reference
+        return schema;
+#else
+        if (schema.Reference?.Id != null)
+            return repository.Schemas[schema.Reference.Id];
+        return schema;
+#endif
+    }
+
+    /// <summary>
+    /// Checks if schema type matches expected type.
+    /// </summary>
+    public static bool IsType(this OpenApiSchema schema, string expectedType)
+    {
+#if OPENAPI_V2
+        if (!schema.Type.HasValue) return false;
+        return expectedType switch
+        {
+            "string" => schema.Type.Value.HasFlag(JsonSchemaType.String),
+            "integer" => schema.Type.Value.HasFlag(JsonSchemaType.Integer),
+            "number" => schema.Type.Value.HasFlag(JsonSchemaType.Number),
+            "boolean" => schema.Type.Value.HasFlag(JsonSchemaType.Boolean),
+            "array" => schema.Type.Value.HasFlag(JsonSchemaType.Array),
+            "object" => schema.Type.Value.HasFlag(JsonSchemaType.Object),
+            _ => false
+        };
+#else
+        return schema.Type == expectedType;
+#endif
+    }
+
+    /// <summary>
+    /// Gets the type as string for assertions.
+    /// </summary>
+    public static string? GetTypeString(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        if (!schema.Type.HasValue) return null;
+        var type = schema.Type.Value;
+        if (type.HasFlag(JsonSchemaType.String)) return "string";
+        if (type.HasFlag(JsonSchemaType.Integer)) return "integer";
+        if (type.HasFlag(JsonSchemaType.Number)) return "number";
+        if (type.HasFlag(JsonSchemaType.Boolean)) return "boolean";
+        if (type.HasFlag(JsonSchemaType.Array)) return "array";
+        if (type.HasFlag(JsonSchemaType.Object)) return "object";
+        return null;
+#else
+        return schema.Type;
+#endif
+    }
+
+    /// <summary>
+    /// Checks if schema is nullable.
+    /// </summary>
+    public static bool IsNullable(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        return schema.Type.HasValue && schema.Type.Value.HasFlag(JsonSchemaType.Null);
+#else
+        return schema.Nullable;
+#endif
+    }
+
+    /// <summary>
+    /// Gets property from schema.
+    /// </summary>
+    public static OpenApiSchema? GetProperty(this OpenApiSchema schema, string key)
+    {
+#if OPENAPI_V2
+        if (schema.Properties?.TryGetValue(key, out var prop) == true)
+            return prop as OpenApiSchema;
+        return null;
+#else
+        if (schema.Properties?.TryGetValue(key, out var prop) == true)
+            return prop;
+        return null;
+#endif
+    }
+
+    /// <summary>
+    /// Generates schema and resolves reference.
+    /// </summary>
+    public static OpenApiSchema GenerateAndResolve<T>(this ISchemaGenerator generator, SchemaRepository repository)
+    {
+        var schema = generator.GenerateSchema(typeof(T), repository);
+#if OPENAPI_V2
+        if (schema is OpenApiSchemaReference schemaRef && schemaRef.Reference?.Id != null)
+        {
+            if (repository.Schemas.TryGetValue(schemaRef.Reference.Id, out var resolved))
+                return resolved as OpenApiSchema ?? new OpenApiSchema();
+        }
+        return schema as OpenApiSchema ?? new OpenApiSchema();
+#else
+        if (schema.Reference?.Id != null)
+            return repository.Schemas[schema.Reference.Id];
+        return schema;
+#endif
+    }
+
+#if OPENAPI_V2
+    /// <summary>
+    /// Resolves schema reference from already generated schema.
+    /// </summary>
+    public static OpenApiSchema GenerateAndResolve<T>(this SchemaRepository repository, IOpenApiSchema schema)
+    {
+        if (schema is OpenApiSchemaReference schemaRef && schemaRef.Reference?.Id != null)
+        {
+            if (repository.Schemas.TryGetValue(schemaRef.Reference.Id, out var resolved))
+                return resolved as OpenApiSchema ?? new OpenApiSchema();
+        }
+        return schema as OpenApiSchema ?? new OpenApiSchema();
+    }
+
+    /// <summary>
+    /// Gets the reference ID from a schema result.
+    /// </summary>
+    public static string? GetRefId(this IOpenApiSchema schema)
+    {
+        if (schema is OpenApiSchemaReference schemaRef)
+            return schemaRef.Reference?.Id;
+        return null;
+    }
+#else
+    /// <summary>
+    /// Resolves schema reference from already generated schema.
+    /// </summary>
+    public static OpenApiSchema GenerateAndResolve<T>(this SchemaRepository repository, OpenApiSchema schema)
+    {
+        if (schema.Reference?.Id != null)
+            return repository.Schemas[schema.Reference.Id];
+        return schema;
+    }
+
+    /// <summary>
+    /// Gets the reference ID from a schema result.
+    /// </summary>
+    public static string? GetRefId(this OpenApiSchema schema)
+    {
+        return schema.Reference?.Id;
+    }
+#endif
+
+    /// <summary>
+    /// Gets the Items schema from an array schema.
+    /// </summary>
+    public static OpenApiSchema? GetItems(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        return schema.Items as OpenApiSchema;
+#else
+        return schema.Items;
+#endif
+    }
+
+    /// <summary>
+    /// Gets Minimum as decimal. In OpenApi 2.x, when exclusive, the value is in ExclusiveMinimum.
+    /// </summary>
+    public static decimal? GetMinimum(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        // In OpenApi 2.x with exclusive, value is in ExclusiveMinimum instead of Minimum
+        var minValue = !string.IsNullOrEmpty(schema.Minimum) ? schema.Minimum :
+                       !string.IsNullOrEmpty(schema.ExclusiveMinimum) ? schema.ExclusiveMinimum : null;
+        return decimal.TryParse(minValue, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var result) ? result : null;
+#else
+        return schema.Minimum;
+#endif
+    }
+
+    /// <summary>
+    /// Gets Maximum as decimal. In OpenApi 2.x, when exclusive, the value is in ExclusiveMaximum.
+    /// </summary>
+    public static decimal? GetMaximum(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        // In OpenApi 2.x with exclusive, value is in ExclusiveMaximum instead of Maximum
+        var maxValue = !string.IsNullOrEmpty(schema.Maximum) ? schema.Maximum :
+                       !string.IsNullOrEmpty(schema.ExclusiveMaximum) ? schema.ExclusiveMaximum : null;
+        return decimal.TryParse(maxValue, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var result) ? result : null;
+#else
+        return schema.Maximum;
+#endif
+    }
+
+    /// <summary>
+    /// Gets ExclusiveMinimum.
+    /// </summary>
+    public static bool? GetExclusiveMinimum(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        // In OpenApi 2.x, ExclusiveMinimum is a string value representing the exclusive minimum
+        // If ExclusiveMinimum has a value, it means exclusive is true
+        return string.IsNullOrEmpty(schema.ExclusiveMinimum) ? null : true;
+#else
+        return schema.ExclusiveMinimum;
+#endif
+    }
+
+    /// <summary>
+    /// Gets ExclusiveMaximum.
+    /// </summary>
+    public static bool? GetExclusiveMaximum(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        // In OpenApi 2.x, ExclusiveMaximum is a string value representing the exclusive maximum
+        // If ExclusiveMaximum has a value, it means exclusive is true
+        return string.IsNullOrEmpty(schema.ExclusiveMaximum) ? null : true;
+#else
+        return schema.ExclusiveMaximum;
+#endif
+    }
+
+    /// <summary>
+    /// Gets AllOf as a list of OpenApiSchema.
+    /// </summary>
+    public static IList<OpenApiSchema> GetAllOf(this OpenApiSchema schema)
+    {
+#if OPENAPI_V2
+        return schema.AllOf?.OfType<OpenApiSchema>().ToList() ?? new List<OpenApiSchema>();
+#else
+        return schema.AllOf ?? new List<OpenApiSchema>();
+#endif
+    }
+}

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/TreeValidatorTest.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/TreeValidatorTest.cs
@@ -1,6 +1,11 @@
 ﻿using System.Collections.Generic;
 using FluentAssertions;
 using FluentValidation;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
@@ -41,11 +46,11 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
                 .GenerateSchema(typeof(Node), schemaRepository);
 
             // if we have gotten this far, huzza, no stack overflow.
-            
-            // MicroElements schema validation should work normally on other non-recursive properties 
-            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            var idProperty = schema.Properties[nameof(Node.Id)];
-            idProperty.Type.Should().Be("string");
+
+            // MicroElements schema validation should work normally on other non-recursive properties
+            var schema = schemaRepository.GetSchema(referenceSchema.GetRefId()!);
+            var idProperty = schema.GetProperty(nameof(Node.Id))!;
+            idProperty.GetTypeString().Should().Be("string");
             idProperty.MinLength.Should().Be(1);
         }
     }

--- a/test/MicroElements.Swashbuckle.FluentValidation.Tests/UnitTestBase.cs
+++ b/test/MicroElements.Swashbuckle.FluentValidation.Tests/UnitTestBase.cs
@@ -9,7 +9,11 @@ using MicroElements.Swashbuckle.FluentValidation.Generation;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+#if OPENAPI_V2
+using Microsoft.OpenApi;
+#else
 using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MicroElements.Swashbuckle.FluentValidation.Tests
@@ -120,7 +124,7 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
             PropertyInfo propertyInfo = expressionBody.Member as PropertyInfo;
             string propertyName = _schemaGenerationOptions.NameResolver.GetPropertyName(propertyInfo);
 
-            var property = schema.Properties[propertyName];
+            var property = schema.GetProperty(propertyName)!;
 
             schemaCheck?.Invoke(property);
 
@@ -146,11 +150,7 @@ namespace MicroElements.Swashbuckle.FluentValidation.Tests
                 serviceProvider: serviceProvider,
                 configureSerializer: configureSerializer);
 
-            OpenApiSchema schema = schemaGenerator
-                .GenerateSchema(typeof(T), schemaRepository);
-
-            if (schema.Reference?.Id != null)
-                schema = schemaRepository.Schemas[schema.Reference.Id];
+            OpenApiSchema schema = schemaGenerator.GenerateAndResolve<T>(schemaRepository);
 
             return schema;
         }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.1.1</VersionPrefix>
+    <VersionPrefix>7.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
…nApi 2.x

- Add net10.0 target framework to all projects
- Add conditional compilation with OPENAPI_V2 for Microsoft.OpenApi 2.x breaking changes
- Create OpenApiSchemaCompatibility.cs layer for cross-version compatibility
- Update schema type handling (string vs JsonSchemaType flags)
- Update nullable handling (Nullable property vs JsonSchemaType.Null flag)
- Update numeric properties (decimal vs string for Min/Max)
- Handle IOpenApiSchema interface changes in filters
- Add TestCompatibility.cs with helper methods for tests
- Bump version to 7.0.0

Fixes #171